### PR TITLE
Add support for tags

### DIFF
--- a/lib/SentryStream.js
+++ b/lib/SentryStream.js
@@ -25,14 +25,15 @@ class SentryStream {
    */
   write(record) {
     const err = record.err;
+    const tags = record.tags;
     const level = this.getSentryLevel(record);
 
     if (err) {
-      const extra = _.omit(record, 'err');
-      this.client.captureException(this.deserializeError(err), { extra, level });
+      const extra = _.omit(record, 'err', 'tags');
+      this.client.captureException(this.deserializeError(err), { extra, level, tags });
     } else {
-      const extra = _.omit(record, 'msg');
-      this.client.captureMessage(record.msg, { extra, level });
+      const extra = _.omit(record, 'msg', 'tags');
+      this.client.captureMessage(record.msg, { extra, level, tags });
     }
     return (true);
   }

--- a/test/stream.definitions.js
+++ b/test/stream.definitions.js
@@ -50,10 +50,11 @@ function givenClient() {
  * @param  {Object} client        the Sentry mocked client
  * @param  {String} expectedLevel the final Sentry level (info, warning or error)
  * @param  {Error} expectedErr   the error throws
- * @param  {Object} expectedExtra  the expected extra sent in Senty extra bundle
+ * @param  {Object} expectedExtra  the expected extra sent in Sentry extra bundle
+ * @param  {Object} expectedTags  the expected tags sent in Sentry extra bundle
  * @return {void}
  */
-function thenClientCapturesException(client, expectedLevel, expectedErr, expectedExtra) {
+function thenClientCapturesException(client, expectedLevel, expectedErr, expectedExtra, expectedTags) {
   // Expected error must be provided
   should.exist(expectedErr);
 
@@ -84,6 +85,9 @@ function thenClientCapturesException(client, expectedLevel, expectedErr, expecte
   assertExtra(args.extra, expectedExtra);
   should.exist(args.extra.msg);
 
+  // Client#captureException: assert sentry kwargs.tags
+  assertTags(args.tags, expectedTags);
+
   // Client#captureMessage must be a spy
   assertSpyCallCount(client.captureMessage, 0);
 }
@@ -93,10 +97,11 @@ function thenClientCapturesException(client, expectedLevel, expectedErr, expecte
  * @param  {Object} client        the Sentry mocked client
  * @param  {String} expectedLevel the final Sentry level (info, warning or error)
  * @param  {String} exptectedMessage   the expected message sent to Sentry
- * @param  {Object} expectedExtra  the expected extra sent in Senty extra bundle
+ * @param  {Object} expectedExtra  the expected extra sent in Sentry extra bundle
+ * @param  {Object} expectedTags the expected tags sent in Sentry extra bundle
  * @return {void}
  */
-function thenClientCapturesMessage(client, expectedLevel, exptectedMessage, expectedExtra) {
+function thenClientCapturesMessage(client, expectedLevel, exptectedMessage, expectedExtra, expectedTags) {
   // Expected message must be provided
   should.exist(exptectedMessage);
 
@@ -127,6 +132,9 @@ function thenClientCapturesMessage(client, expectedLevel, exptectedMessage, expe
 
   // Client#captureMessage: assert sentry kwargs.extra
   assertExtra(args.extra, expectedExtra);
+
+  // Client#captureMessage: assert sentry kwards.tags
+  assertTags(args.tags, expectedTags);
 
   // Client#captureException: must be a spy
   assertSpyCallCount(client.captureException, 0);
@@ -165,6 +173,23 @@ function assertExtra(actual, expected) {
   should.exist(actual);
   actual.should.be.an('object');
   if (expected) {
+    for (const key of Object.keys(expected)) {
+      should.exist(actual[key]);
+      actual[key].should.be.equal(expected[key]);
+    }
+  }
+}
+
+/**
+ * Assert the Sentry tags bundle
+ * @param  {Object} actual   the bundle to assert
+ * @param  {Object} expected the expected bundle
+ * @return {void}
+ */
+function assertTags(actual, expected) {
+  if (expected) {
+    should.exist(actual);
+    actual.should.be.an('object');
     for (const key of Object.keys(expected)) {
       should.exist(actual[key]);
       actual[key].should.be.equal(expected[key]);

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -46,6 +46,16 @@ describe('SentrySteam class', () => {
     definitions.thenClientCapturesMessage(client, 'info', 'Hello Joe Mocha !');
   });
 
+  it('should log a message with tags from logger#info(extraWithTags, message)', () => {
+    const message = 'Hello';
+    const client = definitions.givenClient();
+    const logger = definitions.givenLogger(client, 'debug');
+    const tags = { foo: 'bar' };
+    logger.debug({ tags }, message);
+
+    definitions.thenClientCapturesMessage(client, 'info', message, null, tags);
+  });
+
   it('should log a message from logger#warn(extra, message)', () => {
     const client = definitions.givenClient();
     const logger = definitions.givenLogger(client);
@@ -82,5 +92,16 @@ describe('SentrySteam class', () => {
     logger.debug({ foo: 'bar', err }, 'Hello');
 
     definitions.thenClientCapturesException(client, 'info', err, { msg: 'Hello', foo: 'bar' });
+  });
+
+  it('should log a message with tags from logger#debug(extraWithError, message)', () => {
+    const client = definitions.givenClient();
+    const logger = definitions.givenLogger(client, 'debug');
+    const err = new Error('Hello Error');
+    const tags = { foo: 'bar' };
+
+    logger.debug({ foo: 'bar', err, tags }, 'Hello');
+
+    definitions.thenClientCapturesException(client, 'info', err, { msg: 'Hello', foo: 'bar' }, tags);
   });
 });


### PR DESCRIPTION
Sentry supports the tagging of individual messages using a `tags` property in the `extra` object. This PR adds support to pass these tags through from a Bunyan logger. Tags add a lot of functionality to the Sentry portal, allowing you to filter messages and create rules based on them, in addition to adding useful context, such as version numbers, etc.

Using tags is as simple as adding a `tags` property when logging a message.

``` javascript
let tags = { foo: 'bar' };
logger.({ tags }, 'Hello');
```
