### PR TITLE
Don't use lodash for one function

### DIFF
--- a/lib/SentryStream.js
+++ b/lib/SentryStream.js
@@ -1,6 +1,26 @@
 'use strict';
 
-const _ = require('lodash');
+/**
+ * Omits keys from an object
+ *
+ * @param {Object} obj Original object
+ * @param {Array<String>} toOmit Keys to comit
+ * @returns {Object} A shallow copy of obj with the keys in toOmit omitted.
+ */
+function omit(obj, toOmit) {
+  const newObj = {};
+
+  let key;
+  for (key in obj) {
+    if (obj.hasOwnProperty(key)) {
+      if (toOmit.indexOf(key) === -1) {
+        newObj[key] = obj[key];
+      }
+    }
+  }
+
+  return newObj;
+}
 
 // // //
 
@@ -29,10 +49,10 @@ class SentryStream {
     const level = this.getSentryLevel(record);
 
     if (err) {
-      const extra = _.omit(record, 'err', 'tags');
+      const extra = omit(record, ['err', 'tags']);
       this.client.captureException(this.deserializeError(err), { extra, level, tags });
     } else {
-      const extra = _.omit(record, 'msg', 'tags');
+      const extra = omit(record, ['msg', 'tags']);
       this.client.captureMessage(record.msg, { extra, level, tags });
     }
     return (true);

--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
     "log"
   ],
   "main": "index.js",
-  "dependencies": {
-    "lodash": "~4.3.0"
-  },
   "devDependencies": {
     "bunyan": "~1.6.0",
     "chai": "~3.5.0",


### PR DESCRIPTION
Reduced installed size of module by ~4MB

At the very least you should switch from a `~` pin to a `^` pin.

We use bunyan on server and client side

Somehow (deeply upsetingly) using this module as is (introducing an additional
differently versioned lodash) was enough to cause our minifier (uglify2 via `meteor build`) 
to get V8 OOM killed & produce incorrect ouput when we set `--max-old-space-size=4096`

Javascript is a nightmare. Fin.