### PR TITLE
chore(package.json): update node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "mocha": "_mocha -b"
   },
   "engines": {
-    "node": "4.8.4"
+    "node": ">=4.8.4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
currently, yarn reports the following error when installing on any version greater than 4.8.4.

> error bunyan-sentry-stream@1.2.0: The engine "node" is incompatible with this module. Expected version "4.8.4".
> error Found incompatible module
> info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

this change will allow yarn to successfully install the package on versions of node greater than 4.8.4 (6.x, 8.x, etc).