### PR TITLE
feat: Support `debug` and `fatal` log levels

### DIFF
--- a/lib/SentryStream.js
+++ b/lib/SentryStream.js
@@ -47,12 +47,12 @@ class SentryStream {
   getSentryLevel(record) {
     const level = record.level;
 
-	  if (level === 60) return "fatal";
-	  if (level === 50) return "error";
+    if (level === 60) return "fatal";
+    if (level === 50) return "error";
     if (level === 40) return 'warning';
-	  if (level === 30) return "info";
+    if (level === 30) return "info";
 
-	  return "debug";
+    return "debug";
   }
 
   /**

--- a/lib/SentryStream.js
+++ b/lib/SentryStream.js
@@ -47,12 +47,12 @@ class SentryStream {
   getSentryLevel(record) {
     const level = record.level;
 
-    if (level === 60) return "fatal";
-    if (level === 50) return "error";
+    if (level === 60) return 'fatal';
+    if (level === 50) return 'error';
     if (level === 40) return 'warning';
-    if (level === 30) return "info";
+    if (level === 30) return 'info';
 
-    return "debug";
+    return 'debug';
   }
 
   /**

--- a/lib/SentryStream.js
+++ b/lib/SentryStream.js
@@ -40,17 +40,19 @@ class SentryStream {
 
   /**
    * Convert Bunyan level number to Sentry level label.
-   * Rule : >50=error ; 40=warning ; info otherwise
+   * Rule : 60=fatal; 50=error ; 40=warning ; 30=info; debug otherwise
    * @param  {Object} record Bunyan log record
    * @return {String}        Sentry level
    */
   getSentryLevel(record) {
     const level = record.level;
 
-    if (level >= 50) return 'error';
+	  if (level === 60) return "fatal";
+	  if (level === 50) return "error";
     if (level === 40) return 'warning';
+	  if (level === 30) return "info";
 
-    return 'info';
+	  return "debug";
   }
 
   /**

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -6,7 +6,7 @@ const definitions = require('./stream.definitions');
 
 TEST ALL FOLLOWING BUNYAN LOGGER FORMAT STYLES :
 
-log.info();     // Returns a boolean: is the "info" level enabled?
+log.info();     // Returns a boolean: is the 'info' level enabled?
                 // This is equivalent to `log.isInfoEnabled()` or
                 // `log.isEnabledFor(INFO)` in log4j.
 
@@ -14,15 +14,15 @@ log.info('hi');                     // Log a simple string message (or number).
 log.info('hi %s', bob, anotherVar); // Uses `util.format` for msg formatting.
 
 log.info({foo: 'bar'}, 'hi');
-                // The first field can optionally be a "fields" object, which
+                // The first field can optionally be a 'fields' object, which
                 // is merged into the log record.
 
 log.info(err);  // Special case to log an `Error` instance to the record.
-                // This adds an "err" field with exception details
-                // (including the stack) and sets "msg" to the exception
+                // This adds an 'err' field with exception details
+                // (including the stack) and sets 'msg' to the exception
                 // message.
 log.info(err, 'more on this: %s', more);
-                // ... or you can specify the "msg".
+                // ... or you can specify the 'msg'.
 
 log.info({foo: 'bar', err: err}, 'some msg about this error');
                 // To pass in an Error *and* other fields, use the `err`
@@ -36,7 +36,7 @@ describe('SentrySteam class', () => {
     const logger = definitions.givenLogger(client, 'debug');
     logger.debug(message);
 
-    definitions.thenClientCapturesMessage(client, "debug", message);
+    definitions.thenClientCapturesMessage(client, 'debug', message);
   });
 
   it('should log a message from logger#info(message, messageArgs)', () => {
@@ -53,7 +53,7 @@ describe('SentrySteam class', () => {
     const tags = { foo: 'bar' };
     logger.debug({ tags }, message);
 
-    definitions.thenClientCapturesMessage(client, "debug", message, null, tags);
+    definitions.thenClientCapturesMessage(client, 'debug', message, null, tags);
   });
 
   it('should log a message from logger#warn(extra, message)', () => {
@@ -84,25 +84,25 @@ describe('SentrySteam class', () => {
     definitions.thenClientCapturesException(client, 'error', err, { msg: 'Hello Joe Mocha !' });
   });
 
-  it("should log a message from logger#fatal(error)", () => {
+  it('should log a message from logger#fatal(error)', () => {
     const client = definitions.givenClient();
     const logger = definitions.givenLogger(client);
-    const err = new Error("Hello Error");
+    const err = new Error('Hello Error');
     err.code = 400;
     err.signal = 400;
     logger.fatal(err);
 
-    definitions.thenClientCapturesException(client, "fatal", err);
+    definitions.thenClientCapturesException(client, 'fatal', err);
   });
 
-  it("should log a message from logger#fatal(error, message, messageArgs)", () => {
+  it('should log a message from logger#fatal(error, message, messageArgs)', () => {
     const client = definitions.givenClient();
     const logger = definitions.givenLogger(client);
-    const err = new Error("Hello Error");
+    const err = new Error('Hello Error');
 
-    logger.fatal(err, "Hello %s", "Joe Mocha", "!");
+    logger.fatal(err, 'Hello %s', 'Joe Mocha', '!');
 
-    definitions.thenClientCapturesException(client, "fatal", err, {msg: "Hello Joe Mocha !"});
+    definitions.thenClientCapturesException(client, 'fatal', err, { msg: 'Hello Joe Mocha !' });
   });
 
   it('should log a message from logger#debug(extraWithError, message)', () => {
@@ -112,7 +112,7 @@ describe('SentrySteam class', () => {
 
     logger.debug({ foo: 'bar', err }, 'Hello');
 
-    definitions.thenClientCapturesException(client, "debug", err, {msg: "Hello", foo: "bar"});
+    definitions.thenClientCapturesException(client, 'debug', err, { msg: 'Hello', foo: 'bar' });
   });
 
   it('should log a message with tags from logger#debug(extraWithError, message)', () => {
@@ -123,6 +123,6 @@ describe('SentrySteam class', () => {
 
     logger.debug({ foo: 'bar', err, tags }, 'Hello');
 
-    definitions.thenClientCapturesException(client, "debug", err, {msg: "Hello", foo: "bar"}, tags);
+    definitions.thenClientCapturesException(client, 'debug', err, { msg: 'Hello', foo: 'bar' }, tags);
   });
 });

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -36,7 +36,7 @@ describe('SentrySteam class', () => {
     const logger = definitions.givenLogger(client, 'debug');
     logger.debug(message);
 
-	  definitions.thenClientCapturesMessage(client, "debug", message);
+    definitions.thenClientCapturesMessage(client, "debug", message);
   });
 
   it('should log a message from logger#info(message, messageArgs)', () => {
@@ -53,7 +53,7 @@ describe('SentrySteam class', () => {
     const tags = { foo: 'bar' };
     logger.debug({ tags }, message);
 
-	  definitions.thenClientCapturesMessage(client, "debug", message, null, tags);
+    definitions.thenClientCapturesMessage(client, "debug", message, null, tags);
   });
 
   it('should log a message from logger#warn(extra, message)', () => {
@@ -84,26 +84,26 @@ describe('SentrySteam class', () => {
     definitions.thenClientCapturesException(client, 'error', err, { msg: 'Hello Joe Mocha !' });
   });
 
-	it("should log a message from logger#fatal(error)", () => {
-		const client = definitions.givenClient();
-		const logger = definitions.givenLogger(client);
-		const err = new Error("Hello Error");
-		err.code = 400;
-		err.signal = 400;
-		logger.fatal(err);
+  it("should log a message from logger#fatal(error)", () => {
+    const client = definitions.givenClient();
+    const logger = definitions.givenLogger(client);
+    const err = new Error("Hello Error");
+    err.code = 400;
+    err.signal = 400;
+    logger.fatal(err);
 
-		definitions.thenClientCapturesException(client, "fatal", err);
-	});
+    definitions.thenClientCapturesException(client, "fatal", err);
+  });
 
-	it("should log a message from logger#fatal(error, message, messageArgs)", () => {
-		const client = definitions.givenClient();
-		const logger = definitions.givenLogger(client);
-		const err = new Error("Hello Error");
+  it("should log a message from logger#fatal(error, message, messageArgs)", () => {
+    const client = definitions.givenClient();
+    const logger = definitions.givenLogger(client);
+    const err = new Error("Hello Error");
 
-		logger.fatal(err, "Hello %s", "Joe Mocha", "!");
+    logger.fatal(err, "Hello %s", "Joe Mocha", "!");
 
-		definitions.thenClientCapturesException(client, "fatal", err, {msg: "Hello Joe Mocha !"});
-	});
+    definitions.thenClientCapturesException(client, "fatal", err, {msg: "Hello Joe Mocha !"});
+  });
 
   it('should log a message from logger#debug(extraWithError, message)', () => {
     const client = definitions.givenClient();
@@ -112,7 +112,7 @@ describe('SentrySteam class', () => {
 
     logger.debug({ foo: 'bar', err }, 'Hello');
 
-	  definitions.thenClientCapturesException(client, "debug", err, {msg: "Hello", foo: "bar"});
+    definitions.thenClientCapturesException(client, "debug", err, {msg: "Hello", foo: "bar"});
   });
 
   it('should log a message with tags from logger#debug(extraWithError, message)', () => {
@@ -123,6 +123,6 @@ describe('SentrySteam class', () => {
 
     logger.debug({ foo: 'bar', err, tags }, 'Hello');
 
-	  definitions.thenClientCapturesException(client, "debug", err, {msg: "Hello", foo: "bar"}, tags);
+    definitions.thenClientCapturesException(client, "debug", err, {msg: "Hello", foo: "bar"}, tags);
   });
 });

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -36,7 +36,7 @@ describe('SentrySteam class', () => {
     const logger = definitions.givenLogger(client, 'debug');
     logger.debug(message);
 
-    definitions.thenClientCapturesMessage(client, 'info', message);
+	  definitions.thenClientCapturesMessage(client, "debug", message);
   });
 
   it('should log a message from logger#info(message, messageArgs)', () => {
@@ -53,7 +53,7 @@ describe('SentrySteam class', () => {
     const tags = { foo: 'bar' };
     logger.debug({ tags }, message);
 
-    definitions.thenClientCapturesMessage(client, 'info', message, null, tags);
+	  definitions.thenClientCapturesMessage(client, "debug", message, null, tags);
   });
 
   it('should log a message from logger#warn(extra, message)', () => {
@@ -84,6 +84,27 @@ describe('SentrySteam class', () => {
     definitions.thenClientCapturesException(client, 'error', err, { msg: 'Hello Joe Mocha !' });
   });
 
+	it("should log a message from logger#fatal(error)", () => {
+		const client = definitions.givenClient();
+		const logger = definitions.givenLogger(client);
+		const err = new Error("Hello Error");
+		err.code = 400;
+		err.signal = 400;
+		logger.fatal(err);
+
+		definitions.thenClientCapturesException(client, "fatal", err);
+	});
+
+	it("should log a message from logger#fatal(error, message, messageArgs)", () => {
+		const client = definitions.givenClient();
+		const logger = definitions.givenLogger(client);
+		const err = new Error("Hello Error");
+
+		logger.fatal(err, "Hello %s", "Joe Mocha", "!");
+
+		definitions.thenClientCapturesException(client, "fatal", err, {msg: "Hello Joe Mocha !"});
+	});
+
   it('should log a message from logger#debug(extraWithError, message)', () => {
     const client = definitions.givenClient();
     const logger = definitions.givenLogger(client, 'debug');
@@ -91,7 +112,7 @@ describe('SentrySteam class', () => {
 
     logger.debug({ foo: 'bar', err }, 'Hello');
 
-    definitions.thenClientCapturesException(client, 'info', err, { msg: 'Hello', foo: 'bar' });
+	  definitions.thenClientCapturesException(client, "debug", err, {msg: "Hello", foo: "bar"});
   });
 
   it('should log a message with tags from logger#debug(extraWithError, message)', () => {
@@ -102,6 +123,6 @@ describe('SentrySteam class', () => {
 
     logger.debug({ foo: 'bar', err, tags }, 'Hello');
 
-    definitions.thenClientCapturesException(client, 'info', err, { msg: 'Hello', foo: 'bar' }, tags);
+	  definitions.thenClientCapturesException(client, "debug", err, {msg: "Hello", foo: "bar"}, tags);
   });
 });


### PR DESCRIPTION
Per https://docs.sentry.io/clients/node/usage/, they now support `debug` and `fatal`, so why not add them in here?